### PR TITLE
SUBMARINE-120 Wrong parent.artifactId name in yarnservice-runtime

### DIFF
--- a/submarine-runtime/yarnservice-runtime/pom.xml
+++ b/submarine-runtime/yarnservice-runtime/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.apache.submarine</groupId>
-    <artifactId>submarine-runtime-parent</artifactId>
+    <artifactId>submarine-runtime</artifactId>
     <version>0.3.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>


### PR DESCRIPTION
### What is this PR for?
SUBMARINE-120 Wrong parent.artifactId name in yarnservice-runtime

### What type of PR is it?
[Bug Fix]

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/SUBMARINE-120

### How should this be tested?
* First time? Setup Travis CI as described on https://submarine.apache.org/contribution/contributions.html#continuous-integration
* Strongly recommended: add automated unit tests for any new or changed behavior
* Outline any manual steps to test the PR here.

### Screenshots (if appropriate)

### Questions:
* Does the licenses files need update? Yes/No
* Is there breaking changes for older versions? Yes/No
* Does this needs documentation? Yes/No
